### PR TITLE
register rule: Allow region picker to be unset in rule spec.

### DIFF
--- a/docs/demo/attila_job_reg_rule.hcl
+++ b/docs/demo/attila_job_reg_rule.hcl
@@ -9,6 +9,6 @@ region_filter {
 
 region_picker {
   expression {
-    selector = "filter(regions, .Group == \"europe\" )"
+    selector = "filter(regions, .Group == \"europe\")"
   }
 }

--- a/internal/cmd/job/register/rule/rule.go
+++ b/internal/cmd/job/register/rule/rule.go
@@ -34,7 +34,7 @@ func outputRule(cliCtx *cli.Context, r *api.JobRegisterRule) {
 		fmt.Sprintf("Name|%s", r.Name),
 		fmt.Sprintf("Region Contexts|%s", contextsAsString(r.RegionContexts)),
 		fmt.Sprintf("Region Filter|%s", r.RegionFilter.Expression.Selector),
-		fmt.Sprintf("Region Picker|%s", r.RegionPicker.Expression.Selector),
+		fmt.Sprintf("Region Picker|%s", formatRegionPicker(r.RegionPicker)),
 		fmt.Sprintf("Create Time|%s", helper.FormatTime(r.Metadata.CreateTime)),
 		fmt.Sprintf("Update Time|%s", helper.FormatTime(r.Metadata.UpdateTime)),
 	}))
@@ -47,4 +47,11 @@ func contextsAsString(ctxs []api.JobRegisterRuleRegionContext) string {
 		s = append(s, string(regionCtx))
 	}
 	return strings.Join(s, ", ")
+}
+
+func formatRegionPicker(rp *api.JobRegisterRulePicker) string {
+	if rp != nil && rp.Expression != nil {
+		return rp.Expression.Selector
+	}
+	return ""
 }

--- a/internal/cmd/job/register/rule/rule_test.go
+++ b/internal/cmd/job/register/rule/rule_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package rule
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/pkg/api"
+)
+
+func Test_formatRegionPicker(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		inputRulePicker *api.JobRegisterRulePicker
+		expectedOutput  string
+	}{
+		{
+			name:            "nil picker",
+			inputRulePicker: nil,
+			expectedOutput:  "",
+		},
+		{
+			name:            "nil expression",
+			inputRulePicker: &api.JobRegisterRulePicker{},
+			expectedOutput:  "",
+		},
+		{
+			name: "populated expression selector",
+			inputRulePicker: &api.JobRegisterRulePicker{
+				Expression: &api.JobRegisterRuleFilterExpression{
+					Selector: "this.expression",
+				},
+			},
+			expectedOutput: "this.expression",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := formatRegionPicker(tc.inputRulePicker)
+			must.Eq(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}

--- a/internal/server/state/job_register_rule.go
+++ b/internal/server/state/job_register_rule.go
@@ -3,6 +3,15 @@
 
 package state
 
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/expr-lang/expr"
+	"github.com/hashicorp/go-multierror"
+)
+
 type JobRegisterRuleState interface {
 	Create(*JobRegisterRuleCreateReq) (*JobRegisterRuleCreateResp, *ErrorResp)
 	Delete(*JobRegisterRuleDeleteReq) (*JobRegisterRuleDeleteResp, *ErrorResp)
@@ -46,7 +55,26 @@ type JobRegisterRule struct {
 	Metadata       *Metadata                      `json:"metadata"`
 }
 
-func (a *JobRegisterRule) Validate() error { return nil }
+// Validate performs validation of the job registration rule. It is safe
+// to call without checking whether the rule object is nil, although this would
+// indicate a serious error in the functionality of the caller.
+func (a *JobRegisterRule) Validate() error {
+
+	// Protect against complete incorrect use which would cause the server to
+	// panic. This does not use the multierror because it will be the only error
+	// to occur.
+	if a == nil {
+		return errors.New("job register rule is empty")
+	}
+
+	var mErr *multierror.Error
+
+	if err := a.RegionPicker.Validate(); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	return mErr.ErrorOrNil()
+}
 
 func (a *JobRegisterRule) Stub() *JobRegisterRuleStub {
 	return &JobRegisterRuleStub{
@@ -69,7 +97,33 @@ type JobRegisterRulePicker struct {
 }
 
 type JobRegisterRuleFilterExpression struct {
-	Selelctor string `json:"selector"`
+	Selector string `json:"selector"`
+}
+
+// Validate performs validation of the job registration rule picker. It is safe
+// to call without checking whether the picker object is nil.
+func (j *JobRegisterRulePicker) Validate() error {
+
+	// Protect against the rule picker being nil, so callers do not have to do
+	// this.
+	if j == nil {
+		return nil
+	}
+
+	// If the expression is nil, we have nothing to valid. This will change if
+	// alternate picker functionality is added.
+	if j.Expression == nil {
+		return nil
+	}
+
+	// Ensure the expression compiles with an expected slice result. This is as
+	// close as we can get to validation without running the expression against
+	// some data.
+	if _, err := expr.Compile(j.Expression.Selector, expr.AsKind(reflect.Slice)); err != nil {
+		return fmt.Errorf("failed to compile rule picker selector: %w", err)
+	}
+
+	return nil
 }
 
 type JobRegisterRuleRegionContext string

--- a/internal/server/state/job_register_rule_test.go
+++ b/internal/server/state/job_register_rule_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestJobRegisterRule_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		inputRule   *JobRegisterRule
+		expectedErr bool
+	}{
+		{
+			name:        "nil rule",
+			inputRule:   nil,
+			expectedErr: true,
+		},
+		{
+			name: "valid rule",
+			inputRule: &JobRegisterRule{
+				RegionPicker: &JobRegisterRulePicker{
+					Expression: &JobRegisterRuleFilterExpression{
+						Selector: "filter(regions, .Group == \"europe\")",
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid region picker expression",
+			inputRule: &JobRegisterRule{
+				RegionPicker: &JobRegisterRulePicker{
+					Expression: &JobRegisterRuleFilterExpression{
+						Selector: "any(region_namespace, {.Name == \"platform\"})",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputRule.Validate()
+			if tc.expectedErr {
+				must.Error(t, actualOutput)
+			} else {
+				must.NoError(t, actualOutput)
+			}
+		})
+	}
+}
+
+func TestJobRegisterRulePicker_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		inputRulePicker *JobRegisterRulePicker
+		expectedErr     bool
+	}{
+		{
+			name:            "nil picker",
+			inputRulePicker: nil,
+			expectedErr:     false,
+		},
+		{
+			name:            "nil expression",
+			inputRulePicker: &JobRegisterRulePicker{},
+			expectedErr:     false,
+		},
+		{
+			name: "invalid expression selector",
+			inputRulePicker: &JobRegisterRulePicker{
+				Expression: &JobRegisterRuleFilterExpression{
+					Selector: "",
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "valid expression selector",
+			inputRulePicker: &JobRegisterRulePicker{
+				Expression: &JobRegisterRuleFilterExpression{
+					Selector: "filter(regions, .Group == \"europe\")",
+				},
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputRulePicker.Validate()
+			if tc.expectedErr {
+				must.Error(t, actualOutput)
+			} else {
+				must.NoError(t, actualOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Once the regions have passed through the rule filter, the operator may want all resulting regions to be registered to. In the current situation, the operator would need to write a rule picker expression which made this possible.

This change allows the rule specification to be created without specifying a region picker. In this case, all regions that passed through the filter would immediately move onto the registration planning.

Closes #5 