### PR TITLE
state: Add new state backend which writes to the local filesystem.

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -19,7 +19,7 @@ $ nomad agent -dev -config nomad_euw2.hcl
 From the root directory of the Attila repository you should first run `make` to generate the Attila
 binary. From within this directory, you can then start an Attila server.
 ```console
-$ ../../bin/attila server run -log-level=debug
+$ ../../bin/attila server run --log-level=debug --state-memory-enabled=true
 ```
 
 Once the server is running you can first configure the target Nomad regions.

--- a/internal/cmd/server/run.go
+++ b/internal/cmd/server/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rasorp/attila/internal/cmd/helper"
 	"github.com/rasorp/attila/internal/helper/file"
 	"github.com/rasorp/attila/internal/server"
+	"github.com/rasorp/attila/internal/state"
 )
 
 func runCommand() *cli.Command {
@@ -74,8 +75,18 @@ func runFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:  "state-memory-enabled",
-			Value: true,
+			Value: false,
 			Usage: "Enable the memory state backend",
+		},
+		&cli.BoolFlag{
+			Name:  "state-file-enabled",
+			Value: false,
+			Usage: "Enable the file state backend",
+		},
+		&cli.StringFlag{
+			Name:  "state-file-path",
+			Value: "",
+			Usage: "The local directory to store state",
 		},
 	}
 }
@@ -121,9 +132,15 @@ func generateRunConfig(cliCtx *cli.Context) (*server.Config, error) {
 		defaultCfg.Log.IncludeLine = &line
 	}
 
-	//
 	if memoryState := cliCtx.Bool("state-memory-enabled"); memoryState {
-		defaultCfg.State.Memory.Enabled = &memoryState
+		defaultCfg.State.Memory = &state.MemoryConfig{Enable: &memoryState}
+	}
+
+	if fileState := cliCtx.Bool("state-file-enabled"); fileState {
+		defaultCfg.State.File = &state.FileConfig{
+			Enable: &fileState,
+			Path:   cliCtx.String("state-file-path"),
+		}
 	}
 
 	if err := defaultCfg.Validate(); err != nil {

--- a/internal/helper/file/atomic.go
+++ b/internal/helper/file/atomic.go
@@ -1,0 +1,54 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWrite performs an atomic file write by writing to a temporary file
+// before moving it to the desired location.
+func AtomicWrite(filename string, data []byte, perm os.FileMode) error {
+
+	existingFile, err := os.Stat(filename)
+	if err == nil && !existingFile.Mode().IsRegular() {
+		return errors.New("file is not a regular file")
+	}
+
+	// Generate a temporary file using the desired name as a prefix. It writes
+	// this to the same target directory as the end file.
+	f, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename)+".tmp")
+	if err != nil {
+		return err
+	}
+
+	tmpFileName := f.Name()
+
+	var writeErr error
+
+	// Run a cleanup function that will perform a best effort removal of the
+	// temporary file if we encounter an error.
+	defer func(writeErr error) {
+		if writeErr != nil {
+			_ = f.Close()
+			_ = os.Remove(tmpFileName)
+		}
+	}(writeErr)
+
+	if _, writeErr = f.Write(data); writeErr != nil {
+		return writeErr
+	}
+	if writeErr = f.Chmod(perm); writeErr != nil {
+		return writeErr
+	}
+	if writeErr = f.Sync(); writeErr != nil {
+		return writeErr
+	}
+	if writeErr = f.Close(); writeErr != nil {
+		return writeErr
+	}
+	return os.Rename(tmpFileName, filename)
+}

--- a/internal/helper/test/mock/mock.go
+++ b/internal/helper/test/mock/mock.go
@@ -1,0 +1,81 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+import (
+	"github.com/oklog/ulid/v2"
+
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func Region() *state.Region {
+	return &state.Region{
+		Name:  "mock-" + ulid.Make().String(),
+		Group: "europe",
+		Auth: &state.RegionAuth{
+			Token: "very-secret-token",
+		},
+		API: []*state.RegionAPI{
+			{
+				Address: "http://10.0.0.10:4646",
+				Default: true,
+			},
+			{
+				Address: "http://10.0.0.11:4646",
+				Default: false,
+			},
+			{
+				Address: "http://10.0.0.12:4646",
+				Default: false,
+			},
+		},
+		TLS: &state.RegionTLS{
+			CACert:     "-----BEGIN CERTIFICATE-----\nMIIDCTCCAq+gAwIBAgIQKbjUtElJSSdrCrvFQq1uzDAKBggqhkjOPQQDAjCBxzEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2Nv\nMRowGAYDVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAV\nBgNVBAoTDkhhc2hpQ29ycCBJbmMuMQ4wDAYDVQQLEwVOb21hZDE+MDwGA1UEAxM1\nTm9tYWQgQWdlbnQgQ0EgNTU0NTgwNDQ2MDM3MzgxODg1NTYwOTU4NTQ1MjQ0MTcw\nMTE0MDQwHhcNMjUwNzA1MTEwMzMwWhcNMzAwNzA0MTEwMzMwWjCBxzELMAkGA1UE\nBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRowGAYD\nVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAVBgNVBAoT\nDkhhc2hpQ29ycCBJbmMuMQ4wDAYDVQQLEwVOb21hZDE+MDwGA1UEAxM1Tm9tYWQg\nQWdlbnQgQ0EgNTU0NTgwNDQ2MDM3MzgxODg1NTYwOTU4NTQ1MjQ0MTcwMTE0MDQw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ3nCAE8gHFQei7qd/JINv8bsNBKrqB\n700SWtXOnugCpB0BOXcBl65sUT1WasbEij6T0Hf6ETPiiNXyssZGTBIho3sweTAO\nBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgdhO0EdKo\n1E9YtyErPLBldP6YqBj7TxNe3tmCjyF9dl0wKwYDVR0jBCQwIoAgdhO0EdKo1E9Y\ntyErPLBldP6YqBj7TxNe3tmCjyF9dl0wCgYIKoZIzj0EAwIDSAAwRQIgBS8zAC+t\nPl6Gprpk7xm5jdvrLnm/aBh88DBxM5crcD8CIQDl510EtK2oFIzSdzydyG5GGA/g\ny0WMYMTB04KOek6zUQ==\n-----END CERTIFICATE-----",
+			ClientCert: "-----BEGIN CERTIFICATE-----\nMIICrjCCAlSgAwIBAgIQLQxOsqmULY2y2EfUgKzzBjAKBggqhkjOPQQDAjCBxzEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2Nv\nMRowGAYDVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAV\nBgNVBAoTDkhhc2hpQ29ycCBJbmMuMQ4wDAYDVQQLEwVOb21hZDE+MDwGA1UEAxM1\nTm9tYWQgQWdlbnQgQ0EgNTU0NTgwNDQ2MDM3MzgxODg1NTYwOTU4NTQ1MjQ0MTcw\nMTE0MDQwHhcNMjUwNzA1MTEwNDI5WhcNMjYwNzA1MTEwNDI5WjAeMRwwGgYDVQQD\nExNjbGllbnQuZ2xvYmFsLm5vbWFkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\ncO08iQM220O7eBm5VPH9MrUAzaHKY5u5jn3jl3LdCD8oHPUCCwdgRqC+JSaB2ALL\nMwPZuaDWXyQwt3tgkyYmgqOByTCBxjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYw\nFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwKQYDVR0OBCIEIEj3\n1eswrouGaCvFSptIT8RjfMatMReVHkC3WcTgerCmMCsGA1UdIwQkMCKAIHYTtBHS\nqNRPWLchKzywZXT+mKgY+08TXt7Zgo8hfXZdMC8GA1UdEQQoMCaCE2NsaWVudC5n\nbG9iYWwubm9tYWSCCWxvY2FsaG9zdIcEfwAAATAKBggqhkjOPQQDAgNIADBFAiEA\nvct1V1qVoZLcrvObu8gFvjEpHxDpvhNf53SI3GPvj9kCIHvsjyVlnj82pgjL2yh2\nlbzvj3aoyUCKkFBsjYTcVXND\n-----END CERTIFICATE-----",
+			ClientKey:  "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEINRy4CwInWabRFidIR1+vQYXm1KP+GomvOAibzxfVv2HoAoGCCqGSM49\nAwEHoUQDQgAEcO08iQM220O7eBm5VPH9MrUAzaHKY5u5jn3jl3LdCD8oHPUCCwdg\nRqC+JSaB2ALLMwPZuaDWXyQwt3tgkyYmgg==\n-----END EC PRIVATE KEY-----",
+			ServerName: "servername",
+			Insecure:   true,
+		},
+	}
+}
+
+func JobRegistrationMethod() *state.JobRegisterMethod {
+	return &state.JobRegisterMethod{
+		Name:     "mock-" + ulid.Make().String(),
+		Selector: "Namespace == \"platform\"",
+		Rules: []*state.JobRegisterMethodRuleLink{
+			{Name: "mock-" + ulid.Make().String()},
+			{Name: "mock-" + ulid.Make().String()},
+			{Name: "mock-" + ulid.Make().String()},
+		},
+	}
+}
+
+func JobRegistrationPlan() *state.JobRegisterPlan {
+	return &state.JobRegisterPlan{
+		ID:           ulid.Make(),
+		JobID:        "example",
+		JobNamespace: "default",
+	}
+}
+
+func JobRegistrationRule() *state.JobRegisterRule {
+	return &state.JobRegisterRule{
+		Name: "mock-" + ulid.Make().String(),
+		RegionContexts: []state.JobRegisterRuleRegionContext{
+			state.JobRegisterRuleContextNamespace,
+			state.JobRegisterRuleContextNodePool,
+		},
+		RegionFilter: &state.JobRegisterRuleFilter{
+			Expression: &state.JobRegisterRuleFilterExpression{
+				Selector: "any(region_namespace, {.Name == \"platform\"})",
+			},
+		},
+		RegionPicker: &state.JobRegisterRulePicker{
+			Expression: &state.JobRegisterRuleFilterExpression{
+				Selector: "filter(regions, .Group == \"europe\")",
+			},
+		},
+	}
+}

--- a/internal/state/config.go
+++ b/internal/state/config.go
@@ -5,33 +5,64 @@ package state
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
-	"github.com/rasorp/attila/internal/helper/pointer"
+	"github.com/hashicorp/go-multierror"
 )
 
 type Config struct {
-	Memory *MemoryConfig `hcl:"memory,optional"`
+	Memory *MemoryConfig `hcl:"memory,block"`
+	File   *FileConfig   `hcl:"file,block"`
 }
 
-type MemoryConfig struct {
-	Enabled *bool `hcl:"enabled,optional"`
-}
-
+// DefaultConfig returns the default configuration for the Attila storage
+// backend. This does not enable any backend, so operators must be aware of this
+// when running the server. While this adds some cognitive overhead, it is easy
+// enough to supply a single flag to enable the memory backend.
 func DefaultConfig() *Config {
-	return &Config{
-		Memory: &MemoryConfig{Enabled: pointer.Of(true)},
-	}
+	return &Config{}
 }
 
+// Validate performs validation on the config object and all nested
+// configuration blocks. The function can be called safely without checking if
+// the object is nil. The returned error could be a multierror and should
+// indicate a terminal error in the process which intends to use the config
+// object.
 func (c *Config) Validate() error {
 
 	if c == nil {
 		return errors.New("state config block required")
 	}
-	if c.Memory == nil || !*c.Memory.Enabled {
-		return errors.New("memory state must be enabled")
+
+	var (
+		numEnabled int
+		mErr       *multierror.Error
+	)
+
+	if c.Memory.Enabled() {
+		numEnabled++
 	}
-	return nil
+
+	if c.File.Enabled() {
+		numEnabled++
+
+		if err := c.File.Validate(); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	// We must have one configured backend.
+	switch numEnabled {
+	case 0:
+		mErr = multierror.Append(mErr, errors.New("no state backend enabled"))
+	case 1:
+	default:
+		mErr = multierror.Append(mErr, errors.New("only one storage backend can be enabled"))
+	}
+
+	return mErr.ErrorOrNil()
 }
 
 func (c *Config) Merge(z *Config) *Config {
@@ -39,13 +70,85 @@ func (c *Config) Merge(z *Config) *Config {
 		return z
 	}
 
+	if z == nil {
+		return c
+	}
+
 	result := *c
 
-	if c.Memory != nil {
-		if c.Memory.Enabled != nil {
-			result.Memory.Enabled = c.Memory.Enabled
+	if z.Memory != nil {
+		if z.Memory.Enable != nil {
+			result.Memory.Enable = z.Memory.Enable
+		}
+	}
+
+	if z.File != nil {
+		if z.File.Enable != nil {
+			result.File.Enable = z.File.Enable
+		}
+		if z.File.Path != "" {
+			result.File.Path = z.File.Path
 		}
 	}
 
 	return &result
+}
+
+type MemoryConfig struct {
+	Enable *bool `hcl:"enabled"`
+}
+
+// Enabled is a helper function that informs the caller if the memory state
+// backend is enabled. It should be used instead of directly querying the
+// enabled boolean pointer.
+func (m *MemoryConfig) Enabled() bool {
+	return m != nil && m.Enable != nil && *m.Enable
+}
+
+type FileConfig struct {
+	Enable *bool  `hcl:"enabled"`
+	Path   string `hcl:"path"`
+}
+
+// Enabled is a helper function that informs the caller if the file state
+// backend is enabled. It should be used instead of directly querying the
+// enable boolean pointer.
+func (f *FileConfig) Enabled() bool {
+	return f != nil && f.Enable != nil && *f.Enable
+}
+
+// Validate performs validation of the file configuration block. If it is not
+// enabled, the validation functionality will not run. The returned error could
+// be a multierror and should indicate a terminal error in the process which
+// intends to use the config object.
+func (f *FileConfig) Validate() error {
+
+	// If the file backend is not enabled, then do not perform any further
+	// validation as we will not be using any of the values.
+	if !f.Enabled() {
+		return nil
+	}
+
+	// Check the directory value is as expected. Without confirming this we
+	// cannot reliably perform further checks, so do not use a multierror here.
+	if f.Path == "" {
+		return errors.New("must set path parameter")
+	}
+	if !filepath.IsAbs(f.Path) {
+		return fmt.Errorf("path %q is not an absolute path", f.Path)
+	}
+
+	var mErr *multierror.Error
+
+	// Reaching this point we have an absolute path configured. This must exist
+	// on the filesystem and be a directory.
+	dir, err := os.Stat(f.Path)
+	if err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+	if dir != nil && !dir.IsDir() {
+		mErr = multierror.Append(mErr, fmt.Errorf("path %q is not a dir", f.Path))
+	}
+
+	return mErr.ErrorOrNil()
 }

--- a/internal/state/config_test.go
+++ b/internal/state/config_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestDefaultConfig(t *testing.T) {
 	defaultConfig := DefaultConfig()
-	must.NotNil(t, defaultConfig.Memory)
-	must.True(t, *defaultConfig.Memory.Enabled)
+	must.NotNil(t, defaultConfig)
+	must.Nil(t, defaultConfig.Memory)
+	must.Nil(t, defaultConfig.File)
 }
 
 func TestConfig_Validate(t *testing.T) {
@@ -34,19 +35,34 @@ func TestConfig_Validate(t *testing.T) {
 			name: "memory enabled",
 			inputConfig: &Config{
 				Memory: &MemoryConfig{
-					Enabled: pointer.Of(true),
+					Enable: pointer.Of(true),
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name: "memory not enabled",
+			name: "no backend enabled",
 			inputConfig: &Config{
 				Memory: &MemoryConfig{
-					Enabled: pointer.Of(false),
+					Enable: pointer.Of(false),
+				},
+				File: &FileConfig{
+					Enable: pointer.Of(false),
 				},
 			},
-			expectedError: errors.New("memory state must be enabled"),
+			expectedError: errors.New("no state backend enabled"),
+		},
+		{
+			name: "all backends enabled",
+			inputConfig: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+				File: &FileConfig{
+					Enable: pointer.Of(true),
+				},
+			},
+			expectedError: errors.New("only one storage backend can be enabled"),
 		},
 	}
 
@@ -58,6 +74,211 @@ func TestConfig_Validate(t *testing.T) {
 				must.ErrorContains(t, actualError, tc.expectedError.Error())
 			} else {
 				must.NoError(t, actualError)
+			}
+		})
+	}
+}
+
+func TestConfig_Merge(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		inputConfig    *Config
+		mergeConfig    *Config
+		expectedOutput *Config
+	}{
+		{
+			name:           "both nil",
+			inputConfig:    nil,
+			mergeConfig:    nil,
+			expectedOutput: nil,
+		},
+		{
+			name:        "input nil",
+			inputConfig: nil,
+			mergeConfig: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+			},
+			expectedOutput: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+			},
+		},
+		{
+			name: "merge nil",
+			inputConfig: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+			},
+			mergeConfig: nil,
+			expectedOutput: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+			},
+		},
+		{
+			name: "full merge",
+			inputConfig: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(false),
+				},
+				File: &FileConfig{
+					Enable: pointer.Of(false),
+					Path:   "/my/path",
+				},
+			},
+			mergeConfig: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+				File: &FileConfig{
+					Enable: pointer.Of(true),
+					Path:   "/my/new/path",
+				},
+			},
+			expectedOutput: &Config{
+				Memory: &MemoryConfig{
+					Enable: pointer.Of(true),
+				},
+				File: &FileConfig{
+					Enable: pointer.Of(true),
+					Path:   "/my/new/path",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, tc.inputConfig.Merge(tc.mergeConfig))
+		})
+	}
+}
+
+func TestMemoryConfig_Enabled(t *testing.T) {
+
+	testCases := []struct {
+		name              string
+		inputMemoryConfig *MemoryConfig
+		expectedOutput    bool
+	}{
+		{
+			name:              "config nil",
+			inputMemoryConfig: nil,
+			expectedOutput:    false,
+		},
+		{
+			name:              "enabled nil",
+			inputMemoryConfig: &MemoryConfig{},
+			expectedOutput:    false,
+		},
+		{
+			name:              "enabled false",
+			inputMemoryConfig: &MemoryConfig{Enable: pointer.Of(false)},
+			expectedOutput:    false,
+		},
+		{
+			name:              "enabled true",
+			inputMemoryConfig: &MemoryConfig{Enable: pointer.Of(true)},
+			expectedOutput:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, tc.inputMemoryConfig.Enabled())
+		})
+	}
+}
+
+func TestFileConfig_Enabled(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		inputFileConfig *FileConfig
+		expectedOutput  bool
+	}{
+		{
+			name:            "config nil",
+			inputFileConfig: nil,
+			expectedOutput:  false,
+		},
+		{
+			name:            "enabled nil",
+			inputFileConfig: &FileConfig{},
+			expectedOutput:  false,
+		},
+		{
+			name:            "enabled false",
+			inputFileConfig: &FileConfig{Enable: pointer.Of(false)},
+			expectedOutput:  false,
+		},
+		{
+			name:            "enabled true",
+			inputFileConfig: &FileConfig{Enable: pointer.Of(true)},
+			expectedOutput:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, tc.inputFileConfig.Enabled())
+		})
+	}
+}
+
+func TestFileConfig_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		inputFileConfig *FileConfig
+		expectedError   bool
+	}{
+		{
+			name: "not enabled",
+			inputFileConfig: &FileConfig{
+				Enable: pointer.Of(false),
+			},
+			expectedError: false,
+		},
+		{
+			name: "empty path",
+			inputFileConfig: &FileConfig{
+				Enable: pointer.Of(true),
+				Path:   "",
+			},
+			expectedError: true,
+		},
+		{
+			name: "not absolute path",
+			inputFileConfig: &FileConfig{
+				Enable: pointer.Of(true),
+				Path:   "~/jrasell",
+			},
+			expectedError: true,
+		},
+		{
+			name: "non-existent path",
+			inputFileConfig: &FileConfig{
+				Enable: pointer.Of(true),
+				Path:   "/jrasell/data",
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputFileConfig.Validate()
+			if tc.expectedError {
+				must.Error(t, actualOutput)
+			} else {
+				must.NoError(t, actualOutput)
 			}
 		})
 	}

--- a/internal/state/file/file.go
+++ b/internal/state/file/file.go
@@ -1,0 +1,138 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/rasorp/attila/internal/helper/file"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+type Store struct {
+	dir             string
+	jobRegMethodDir string
+	jobRegPlanDir   string
+	jobRegRuleDir   string
+	regionDir       string
+	lock            sync.RWMutex
+}
+
+const (
+	jobRegMethodDir = "job/registration/method"
+	jobRegPlanDir   = "job/registration/plan"
+	jobRegRuleDir   = "job/registration/rule"
+	regionDir       = "region"
+)
+
+func New(dir string) (state.State, error) {
+
+	s := Store{
+		dir:             dir,
+		jobRegMethodDir: filepath.Join(dir, jobRegMethodDir),
+		jobRegPlanDir:   filepath.Join(dir, jobRegPlanDir),
+		jobRegRuleDir:   filepath.Join(dir, jobRegRuleDir),
+		regionDir:       filepath.Join(dir, regionDir),
+	}
+
+	for _, subDir := range []string{s.jobRegPlanDir, s.jobRegMethodDir, s.jobRegRuleDir, s.regionDir} {
+
+		// Check the existence of directory. Any error is terminal, except one
+		// indicating the directory doesn't exist, as this is normal expected
+		// behaviour of a new server.
+		fileInfo, err := os.Stat(subDir)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("failed to stat dir: %w", err)
+		}
+
+		// Check that any object found looks like a directory.
+		if fileInfo != nil && !fileInfo.IsDir() {
+			return nil, fmt.Errorf("path %q is file not dir", subDir)
+		}
+
+		// Each directory needs rwx permissions rather than just rw, otherwise
+		// we will not be able to create subdirectories.
+		if err := os.MkdirAll(subDir, 0700); err != nil {
+			return nil, fmt.Errorf("failed to create dir: %w", err)
+		}
+	}
+
+	return &s, nil
+}
+
+func (s *Store) JobRegister() state.JobRegisterState { return &JobRegister{store: s} }
+
+func (s *Store) Region() state.RegionState { return &Region{store: s} }
+
+func (s *Store) Name() string { return "file" }
+
+func createStoreFile(path string, data any) (int, error) {
+
+	existing, err := os.Stat(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return 500, err
+	}
+	if existing != nil {
+		return 400, errors.New("resource already exists")
+	}
+
+	objBytes, err := json.Marshal(data)
+	if err != nil {
+		return 500, err
+	}
+
+	if err := file.AtomicWrite(path, objBytes, 0600); err != nil {
+		return 500, err
+	}
+
+	return 0, nil
+}
+
+func getStoreFile(path string, obj any) (int, error) {
+
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 404, errors.New("resource not found")
+		} else {
+			return 500, err
+		}
+	}
+
+	if err := json.Unmarshal(existing, obj); err != nil {
+		return 500, err
+	}
+
+	return 0, nil
+}
+
+func listStoreFiles(path string, decodeFn func([]byte) error) error {
+	return filepath.WalkDir(path, func(path string, d fs.DirEntry, e error) error {
+
+		if d == nil {
+			return fmt.Errorf("path %q not found", path)
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		fileContent, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return decodeFn(fileContent)
+	})
+}

--- a/internal/state/file/file_test.go
+++ b/internal/state/file/file_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func Test_New(t *testing.T) {
+
+	t.Run("no state", func(t *testing.T) {
+
+		dir := t.TempDir()
+
+		fileStore, err := New(dir)
+		must.NoError(t, err)
+		must.NotNil(t, fileStore)
+
+		for _, subDir := range []string{jobRegMethodDir, jobRegPlanDir, jobRegRuleDir, regionDir} {
+
+			fileInfo, err := os.Stat(filepath.Join(dir, subDir))
+			must.NoError(t, err)
+			must.True(t, fileInfo.IsDir())
+			must.Eq(t, os.ModeDir|os.FileMode(0700), fileInfo.Mode())
+		}
+	})
+
+	t.Run("existing state", func(t *testing.T) {
+
+		dir := t.TempDir()
+
+		// Create an initial instance of the file store.
+		fileStore, err := New(dir)
+		must.NoError(t, err)
+		must.NotNil(t, fileStore)
+
+		// Write a region to our state store.
+		mockRegion := mock.Region()
+
+		createResp, err := fileStore.Region().Create(&state.RegionCreateReq{Region: mockRegion})
+		must.Nil(t, err)
+		must.Eq(t, createResp.Region, mockRegion)
+
+		// Create another instance of the file store.
+		fileStore, err = New(dir)
+		must.NoError(t, err)
+		must.NotNil(t, fileStore)
+
+		// Ensure the region is still there.
+		getResp, err := fileStore.Region().Get(&state.RegionGetReq{RegionName: mockRegion.Name})
+		must.Nil(t, err)
+		must.Eq(t, getResp.Region, mockRegion)
+	})
+
+	t.Run("irregular dir", func(t *testing.T) {
+
+		exec, err := os.Executable()
+		must.NoError(t, err)
+
+		fileStore, err := New(exec)
+		must.Error(t, err)
+		must.Nil(t, fileStore)
+	})
+}
+
+func TestStore_Name(t *testing.T) {
+	fileStore := &Store{}
+	must.Eq(t, "file", fileStore.Name())
+}

--- a/internal/state/file/job_register.go
+++ b/internal/state/file/job_register.go
@@ -1,0 +1,18 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import "github.com/rasorp/attila/internal/server/state"
+
+type JobRegister struct {
+	store *Store
+}
+
+func (j *JobRegister) Method() state.JobRegisterMethodState {
+	return &JobRegisterMethod{store: j.store}
+}
+
+func (j *JobRegister) Plan() state.JobRegisterPlanState { return &JobRegisterPlan{store: j.store} }
+
+func (j *JobRegister) Rule() state.JobRegisterRuleState { return &JobRegisterRule{store: j.store} }

--- a/internal/state/file/job_register_method.go
+++ b/internal/state/file/job_register_method.go
@@ -1,0 +1,82 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+type JobRegisterMethod struct {
+	store *Store
+}
+
+func (j *JobRegisterMethod) Create(req *state.JobRegisterMethodCreateReq) (*state.JobRegisterMethodCreateResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	filePath := filepath.Join(j.store.jobRegMethodDir, req.Method.Name+".json")
+
+	if code, err := createStoreFile(filePath, req.Method); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterMethodCreateResp{Method: req.Method}, nil
+}
+
+func (j *JobRegisterMethod) Delete(req *state.JobRegisterMethodDeleteReq) (*state.JobRegisterMethodDeleteResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	path := filepath.Join(j.store.jobRegMethodDir, req.Name+".json")
+
+	if err := os.Remove(path); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+
+	return &state.JobRegisterMethodDeleteResp{}, nil
+}
+
+func (j *JobRegisterMethod) Get(req *state.JobRegisterMethodGetReq) (*state.JobRegisterMethodGetResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	path := filepath.Join(j.store.jobRegMethodDir, req.Name+".json")
+
+	var decodedMethod state.JobRegisterMethod
+
+	if code, err := getStoreFile(path, &decodedMethod); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterMethodGetResp{Method: &decodedMethod}, nil
+}
+
+func (j *JobRegisterMethod) List(_ *state.JobRegisterMethodListReq) (*state.JobRegisterMethodListResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	var resp state.JobRegisterMethodListResp
+
+	err := listStoreFiles(j.store.jobRegMethodDir, func(bytes []byte) error {
+
+		var decodedMethod state.JobRegisterMethod
+
+		if err := json.Unmarshal(bytes, &decodedMethod); err != nil {
+			return err
+		}
+
+		resp.Methods = append(resp.Methods, &decodedMethod)
+		return nil
+	})
+
+	if err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+	return &resp, nil
+}

--- a/internal/state/file/job_register_method_test.go
+++ b/internal/state/file/job_register_method_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func TestJobRegisterMethod_Create(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockMethod := mock.JobRegistrationMethod()
+
+	createResp1, errResp1 := testState.JobRegister().Method().Create(
+		&state.JobRegisterMethodCreateReq{Method: mockMethod},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockMethod, createResp1.Method)
+
+	createResp2, errResp2 := testState.JobRegister().Method().Create(
+		&state.JobRegisterMethodCreateReq{Method: mockMethod},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, createResp2)
+}
+
+func TestJobRegisterMethod_Delete(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockMethod := mock.JobRegistrationMethod()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Method().Create(
+		&state.JobRegisterMethodCreateReq{Method: mockMethod},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockMethod, createResp1.Method)
+
+	// Attempt two delete calls. This first should succeed but the second should
+	// fail as the file will no longer exist.
+	deleteResp1, errResp1 := testState.JobRegister().Method().Delete(
+		&state.JobRegisterMethodDeleteReq{Name: mockMethod.Name},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, &state.JobRegisterMethodDeleteResp{}, deleteResp1)
+
+	deleteResp2, errResp2 := testState.JobRegister().Method().Delete(
+		&state.JobRegisterMethodDeleteReq{Name: mockMethod.Name},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, deleteResp2)
+}
+
+func TestJobRegisterMethod_Get(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Attempt to read a method that does not exist.
+	getResp1, err := testState.JobRegister().Method().Get(&state.JobRegisterMethodGetReq{Name: "method"})
+	must.Error(t, err)
+	must.Nil(t, getResp1)
+
+	mockMethod := mock.JobRegistrationMethod()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Method().Create(
+		&state.JobRegisterMethodCreateReq{Method: mockMethod},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockMethod, createResp1.Method)
+
+	getResp2, err := testState.JobRegister().Method().Get(&state.JobRegisterMethodGetReq{Name: mockMethod.Name})
+	must.Nil(t, err)
+	must.Eq(t, mockMethod, getResp2.Method)
+}
+
+func TestJobRegisterMethod_List(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Perform an initial test with no methods in state.
+	listResp1, err := testState.JobRegister().Method().List(nil)
+	must.Nil(t, err)
+	must.Len(t, 0, listResp1.Methods)
+
+	// Create a number of methods that we can list out.
+	mockMethods := make([]*state.JobRegisterMethod, 5)
+
+	for i := range mockMethods {
+		mockMethods[i] = mock.JobRegistrationMethod()
+		createResp, err := testState.JobRegister().Method().Create(
+			&state.JobRegisterMethodCreateReq{Method: mockMethods[i]},
+		)
+		must.Nil(t, err)
+		must.NotNil(t, createResp)
+	}
+
+	listResp2, err := testState.JobRegister().Method().List(nil)
+	must.Nil(t, err)
+	must.SliceContainsAll(t, listResp2.Methods, mockMethods)
+}

--- a/internal/state/file/job_register_plan.go
+++ b/internal/state/file/job_register_plan.go
@@ -1,0 +1,82 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+type JobRegisterPlan struct {
+	store *Store
+}
+
+func (j *JobRegisterPlan) Create(req *state.JobRegisterPlanCreateReq) (*state.JobRegisterPlanCreateResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	path := filepath.Join(j.store.jobRegPlanDir, req.Plan.ID.String()+".json")
+
+	if code, err := createStoreFile(path, req.Plan); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterPlanCreateResp{Plan: req.Plan}, nil
+}
+
+func (j *JobRegisterPlan) Delete(req *state.JobRegisterPlanDeleteReq) (*state.JobRegisterPlanDeleteResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	path := filepath.Join(j.store.jobRegPlanDir, req.ID.String()+".json")
+
+	if err := os.Remove(path); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+
+	return &state.JobRegisterPlanDeleteResp{}, nil
+}
+
+func (j *JobRegisterPlan) Get(req *state.JobRegisterPlanGetReq) (*state.JobRegisterPlanGetResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	path := filepath.Join(j.store.jobRegPlanDir, req.ID.String()+".json")
+
+	var decodedPlan state.JobRegisterPlan
+
+	if code, err := getStoreFile(path, &decodedPlan); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterPlanGetResp{Plan: &decodedPlan}, nil
+}
+
+func (j *JobRegisterPlan) List(_ *state.JobRegisterPlanListReq) (*state.JobRegisterPlanListResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	var resp state.JobRegisterPlanListResp
+
+	err := listStoreFiles(j.store.jobRegPlanDir, func(bytes []byte) error {
+
+		var decodedPlan state.JobRegisterPlan
+
+		if err := json.Unmarshal(bytes, &decodedPlan); err != nil {
+			return err
+		}
+
+		resp.Plans = append(resp.Plans, &decodedPlan)
+		return nil
+	})
+
+	if err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+	return &resp, nil
+}

--- a/internal/state/file/job_register_plan_test.go
+++ b/internal/state/file/job_register_plan_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func TestJobRegisterPlan_Create(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockPlan := mock.JobRegistrationPlan()
+
+	createResp1, errResp1 := testState.JobRegister().Plan().Create(
+		&state.JobRegisterPlanCreateReq{Plan: mockPlan},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockPlan, createResp1.Plan)
+
+	createResp2, errResp2 := testState.JobRegister().Plan().Create(
+		&state.JobRegisterPlanCreateReq{Plan: mockPlan},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, createResp2)
+}
+
+func TestJobRegisterPlan_Delete(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockPlan := mock.JobRegistrationPlan()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Plan().Create(
+		&state.JobRegisterPlanCreateReq{Plan: mockPlan},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockPlan, createResp1.Plan)
+
+	// Attempt two delete calls. This first should succeed but the second should
+	// fail as the file will no longer exist.
+	deleteResp1, errResp1 := testState.JobRegister().Plan().Delete(
+		&state.JobRegisterPlanDeleteReq{ID: mockPlan.ID},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, &state.JobRegisterPlanDeleteResp{}, deleteResp1)
+
+	deleteResp2, errResp2 := testState.JobRegister().Plan().Delete(
+		&state.JobRegisterPlanDeleteReq{ID: mockPlan.ID},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, deleteResp2)
+}
+
+func TestJobRegisterPlan_Get(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Attempt to read a method that does not exist.
+	getResp1, err := testState.JobRegister().Plan().Get(&state.JobRegisterPlanGetReq{ID: ulid.Make()})
+	must.Error(t, err)
+	must.Nil(t, getResp1)
+
+	mockPlan := mock.JobRegistrationPlan()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Plan().Create(
+		&state.JobRegisterPlanCreateReq{Plan: mockPlan},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockPlan, createResp1.Plan)
+
+	getResp2, err := testState.JobRegister().Plan().Get(&state.JobRegisterPlanGetReq{ID: mockPlan.ID})
+	must.Nil(t, err)
+	must.Eq(t, mockPlan, getResp2.Plan)
+}
+
+func TestJobRegisterPlan_List(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Perform an initial test with no plans in state.
+	listResp1, err := testState.JobRegister().Plan().List(nil)
+	must.Nil(t, err)
+	must.Len(t, 0, listResp1.Plans)
+
+	// Create a number of plans that we can list out.
+	mockPlans := make([]*state.JobRegisterPlan, 5)
+
+	for i := range mockPlans {
+		mockPlans[i] = mock.JobRegistrationPlan()
+		createResp, err := testState.JobRegister().Plan().Create(
+			&state.JobRegisterPlanCreateReq{Plan: mockPlans[i]},
+		)
+		must.Nil(t, err)
+		must.NotNil(t, createResp)
+	}
+
+	listResp2, err := testState.JobRegister().Plan().List(nil)
+	must.Nil(t, err)
+	must.SliceContainsAll(t, listResp2.Plans, mockPlans)
+}

--- a/internal/state/file/job_register_rule.go
+++ b/internal/state/file/job_register_rule.go
@@ -1,0 +1,82 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+type JobRegisterRule struct {
+	store *Store
+}
+
+func (j *JobRegisterRule) Create(req *state.JobRegisterRuleCreateReq) (*state.JobRegisterRuleCreateResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	path := filepath.Join(j.store.jobRegRuleDir, req.Rule.Name+".json")
+
+	if code, err := createStoreFile(path, req.Rule); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterRuleCreateResp{Rule: req.Rule}, nil
+}
+
+func (j *JobRegisterRule) Delete(req *state.JobRegisterRuleDeleteReq) (*state.JobRegisterRuleDeleteResp, *state.ErrorResp) {
+	j.store.lock.Lock()
+	defer j.store.lock.Unlock()
+
+	path := filepath.Join(j.store.jobRegRuleDir, req.Name+".json")
+
+	if err := os.Remove(path); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+
+	return &state.JobRegisterRuleDeleteResp{}, nil
+}
+
+func (j *JobRegisterRule) Get(req *state.JobRegisterRuleGetReq) (*state.JobRegisterRuleGetResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	path := filepath.Join(j.store.jobRegRuleDir, req.Name+".json")
+
+	var decodedRule state.JobRegisterRule
+
+	if code, err := getStoreFile(path, &decodedRule); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.JobRegisterRuleGetResp{Rule: &decodedRule}, nil
+}
+
+func (j *JobRegisterRule) List(_ *state.JobRegisterRuleListReq) (*state.JobRegisterRuleListResp, *state.ErrorResp) {
+	j.store.lock.RLock()
+	defer j.store.lock.RUnlock()
+
+	var resp state.JobRegisterRuleListResp
+
+	err := listStoreFiles(j.store.jobRegRuleDir, func(bytes []byte) error {
+
+		var decodedRule state.JobRegisterRule
+
+		if err := json.Unmarshal(bytes, &decodedRule); err != nil {
+			return err
+		}
+
+		resp.Rules = append(resp.Rules, &decodedRule)
+		return nil
+	})
+
+	if err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+	return &resp, nil
+}

--- a/internal/state/file/job_register_rule_test.go
+++ b/internal/state/file/job_register_rule_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func TestJobRegisterRule_Create(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockRule := mock.JobRegistrationRule()
+
+	createResp1, errResp1 := testState.JobRegister().Rule().Create(
+		&state.JobRegisterRuleCreateReq{Rule: mockRule},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRule, createResp1.Rule)
+
+	createResp2, errResp2 := testState.JobRegister().Rule().Create(
+		&state.JobRegisterRuleCreateReq{Rule: mockRule},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, createResp2)
+}
+
+func TestJobRegisterRule_Delete(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockRule := mock.JobRegistrationRule()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Rule().Create(
+		&state.JobRegisterRuleCreateReq{Rule: mockRule},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRule, createResp1.Rule)
+
+	// Attempt two delete calls. This first should succeed but the second should
+	// fail as the file will no longer exist.
+	deleteResp1, errResp1 := testState.JobRegister().Rule().Delete(
+		&state.JobRegisterRuleDeleteReq{Name: mockRule.Name},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, &state.JobRegisterRuleDeleteResp{}, deleteResp1)
+
+	deleteResp2, errResp2 := testState.JobRegister().Rule().Delete(
+		&state.JobRegisterRuleDeleteReq{Name: mockRule.Name},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, deleteResp2)
+}
+
+func TestJobRegisterRule_Get(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Attempt to read a rule that does not exist.
+	getResp1, err := testState.JobRegister().Rule().Get(&state.JobRegisterRuleGetReq{Name: "rule"})
+	must.Error(t, err)
+	must.Nil(t, getResp1)
+
+	mockRule := mock.JobRegistrationRule()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.JobRegister().Rule().Create(
+		&state.JobRegisterRuleCreateReq{Rule: mockRule},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRule, createResp1.Rule)
+
+	getResp2, err := testState.JobRegister().Rule().Get(&state.JobRegisterRuleGetReq{Name: mockRule.Name})
+	must.Nil(t, err)
+	must.Eq(t, mockRule, getResp2.Rule)
+}
+
+func TestJobRegisterRule_List(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Perform an initial test with no rules in state.
+	listResp1, err := testState.JobRegister().Rule().List(nil)
+	must.Nil(t, err)
+	must.Len(t, 0, listResp1.Rules)
+
+	// Create a number of rules that we can list out.
+	mockRules := make([]*state.JobRegisterRule, 5)
+
+	for i := range mockRules {
+		mockRules[i] = mock.JobRegistrationRule()
+		createResp, err := testState.JobRegister().Rule().Create(
+			&state.JobRegisterRuleCreateReq{Rule: mockRules[i]},
+		)
+		must.Nil(t, err)
+		must.NotNil(t, createResp)
+	}
+
+	listResp2, err := testState.JobRegister().Rule().List(nil)
+	must.Nil(t, err)
+	must.SliceContainsAll(t, listResp2.Rules, mockRules)
+}

--- a/internal/state/file/region.go
+++ b/internal/state/file/region.go
@@ -1,0 +1,82 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+type Region struct {
+	store *Store
+}
+
+func (r *Region) Create(req *state.RegionCreateReq) (*state.RegionCreateResp, *state.ErrorResp) {
+	r.store.lock.Lock()
+	defer r.store.lock.Unlock()
+
+	path := filepath.Join(r.store.regionDir, req.Region.Name+".json")
+
+	if code, err := createStoreFile(path, req.Region); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.RegionCreateResp{Region: req.Region}, nil
+}
+
+func (r *Region) Delete(req *state.RegionDeleteReq) (*state.RegionDeleteResp, *state.ErrorResp) {
+	r.store.lock.Lock()
+	defer r.store.lock.Unlock()
+
+	path := filepath.Join(r.store.regionDir, req.RegionName+".json")
+
+	if err := os.Remove(path); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+
+	return &state.RegionDeleteResp{}, nil
+}
+
+func (r *Region) Get(req *state.RegionGetReq) (*state.RegionGetResp, *state.ErrorResp) {
+	r.store.lock.RLock()
+	defer r.store.lock.RUnlock()
+
+	path := filepath.Join(r.store.regionDir, req.RegionName+".json")
+
+	var decodedRegion state.Region
+
+	if code, err := getStoreFile(path, &decodedRegion); err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), code)
+	}
+
+	return &state.RegionGetResp{Region: &decodedRegion}, nil
+}
+
+func (r *Region) List(_ *state.RegionListReq) (*state.RegionListResp, *state.ErrorResp) {
+	r.store.lock.RLock()
+	defer r.store.lock.RUnlock()
+
+	var resp state.RegionListResp
+
+	err := listStoreFiles(r.store.regionDir, func(bytes []byte) error {
+
+		var decodedRegion state.Region
+
+		if err := json.Unmarshal(bytes, &decodedRegion); err != nil {
+			return err
+		}
+
+		resp.Regions = append(resp.Regions, &decodedRegion)
+		return nil
+	})
+
+	if err != nil {
+		return nil, state.NewErrorResp(fmt.Errorf("state: %w", err), 500)
+	}
+	return &resp, nil
+}

--- a/internal/state/file/region_test.go
+++ b/internal/state/file/region_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+)
+
+func TestRegion_Create(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockRegion := mock.Region()
+
+	createResp1, errResp1 := testState.Region().Create(&state.RegionCreateReq{Region: mockRegion})
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRegion, createResp1.Region)
+
+	createResp2, errResp2 := testState.Region().Create(&state.RegionCreateReq{Region: mockRegion})
+	must.NotNil(t, errResp2)
+	must.Nil(t, createResp2)
+}
+
+func TestRegion_Delete(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	mockRegion := mock.Region()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.Region().Create(&state.RegionCreateReq{Region: mockRegion})
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRegion, createResp1.Region)
+
+	// Attempt two delete calls. This first should succeed but the second should
+	// fail as the file will no longer exist.
+	deleteResp1, errResp1 := testState.Region().Delete(
+		&state.RegionDeleteReq{RegionName: mockRegion.Name},
+	)
+	must.Nil(t, errResp1)
+	must.Eq(t, &state.RegionDeleteResp{}, deleteResp1)
+
+	deleteResp2, errResp2 := testState.Region().Delete(
+		&state.RegionDeleteReq{RegionName: mockRegion.Name},
+	)
+	must.NotNil(t, errResp2)
+	must.Nil(t, deleteResp2)
+}
+
+func TestRegion_Get(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Attempt to read a region that does not exist.
+	getResp1, err := testState.Region().Get(&state.RegionGetReq{RegionName: "region"})
+	must.Error(t, err)
+	must.Nil(t, getResp1)
+
+	mockRegion := mock.Region()
+
+	// Create our test resource.
+	createResp1, errResp1 := testState.Region().Create(&state.RegionCreateReq{Region: mockRegion})
+	must.Nil(t, errResp1)
+	must.Eq(t, mockRegion, createResp1.Region)
+
+	getResp2, err := testState.Region().Get(&state.RegionGetReq{RegionName: mockRegion.Name})
+	must.Nil(t, err)
+	must.Eq(t, mockRegion, getResp2.Region)
+}
+
+func TestRegion_List(t *testing.T) {
+
+	testState, err := New(t.TempDir())
+	must.NoError(t, err)
+	must.NotNil(t, testState)
+
+	// Perform an initial test with no regions in state.
+	listResp1, err := testState.Region().List(nil)
+	must.Nil(t, err)
+	must.Len(t, 0, listResp1.Regions)
+
+	// Create a number of regions that we can list out.
+	mockRegions := make([]*state.Region, 5)
+
+	for i := range mockRegions {
+		mockRegions[i] = mock.Region()
+		createResp, err := testState.Region().Create(&state.RegionCreateReq{Region: mockRegions[i]})
+		must.Nil(t, err)
+		must.NotNil(t, createResp)
+	}
+
+	listResp2, err := testState.Region().List(nil)
+	must.Nil(t, err)
+	must.SliceContainsAll(t, listResp2.Regions, mockRegions)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -7,17 +7,18 @@ import (
 	"errors"
 
 	"github.com/rasorp/attila/internal/server/state"
+	"github.com/rasorp/attila/internal/state/file"
 	"github.com/rasorp/attila/internal/state/mem"
 )
 
 func NewBackend(cfg *Config) (state.State, error) {
 
-	if cfg.Memory != nil && *cfg.Memory.Enabled {
-		backend, err := mem.New()
-		if err != nil {
-			return nil, err
-		}
-		return backend, nil
+	if cfg.Memory.Enabled() {
+		return mem.New()
+	}
+
+	if cfg.File.Enabled() {
+		return file.New(cfg.File.Path)
 	}
 
 	return nil, errors.New("no state backend configured")

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -5,7 +5,9 @@ package state
 
 import (
 	"errors"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/shoenig/test/must"
 
@@ -22,10 +24,21 @@ func TestNewBackend(t *testing.T) {
 		{
 			name: "memory backend",
 			inputConfig: &Config{
-				Memory: &MemoryConfig{Enabled: pointer.Of(true)},
+				Memory: &MemoryConfig{Enable: pointer.Of(true)},
 			},
 			expectedError: nil,
 			expectedName:  "mem",
+		},
+		{
+			name: "file backend",
+			inputConfig: &Config{
+				File: &FileConfig{
+					Enable: pointer.Of(true),
+					Path:   "/tmp/attila-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+				},
+			},
+			expectedError: nil,
+			expectedName:  "file",
 		},
 		{
 			name:          "no backend",


### PR DESCRIPTION
The new file state backend uses the local filesystem to persist objects. It uses a global lock to avoid data races and writes the data in JSON format which can be easily viewed by humans.

The in-memory backend is now not enabled by default and the operator must make a choice on state when running the server. This adds a little overhead, but it can be as little as a single flag.

Closes #7 