### PR TITLE
nomad: Restore API clients when server starts.

### DIFF
--- a/internal/nomad/client/client.go
+++ b/internal/nomad/client/client.go
@@ -43,6 +43,13 @@ func (c *Clients) Get(name string) (*api.Client, error) {
 	return regionClient, nil
 }
 
+func (c *Clients) Num() int {
+	c.clientsLock.RLock()
+	defer c.clientsLock.RUnlock()
+
+	return len(c.clients)
+}
+
 func (c *Clients) Set(name string, client *api.Client) {
 	c.clientsLock.Lock()
 	c.clients[name] = client

--- a/internal/nomad/controller.go
+++ b/internal/nomad/controller.go
@@ -43,6 +43,8 @@ func (c *Controller) RegionSet(name string, client *api.Client) {
 	c.topology.RegionSet(name, nil)
 }
 
+func (c *Controller) RegionNum() int { return c.clients.Num() }
+
 func (c *Controller) JobRegistrationPlanCreate(apiJob *api.Job, state state.State) (*state.JobRegisterPlan, error) {
 	return job.NewPlanner(*c.logger, &job.PlannerReq{
 		Clients: c.clients,

--- a/internal/nomad/topology/topology.go
+++ b/internal/nomad/topology/topology.go
@@ -57,6 +57,13 @@ func (c *Topology) RegionDelete(name string) {
 	}
 }
 
+func (c *Topology) RegionNum() int {
+	c.regionsLock.RLock()
+	defer c.regionsLock.RUnlock()
+
+	return len(c.regions)
+}
+
 func (c *Topology) GetTopologies() []*nomad.Overview {
 	c.regionsLock.RLock()
 	defer c.regionsLock.RUnlock()

--- a/internal/server/nomad/nomad.go
+++ b/internal/server/nomad/nomad.go
@@ -30,6 +30,11 @@ type ClientController interface {
 
 	// RegionSet
 	RegionSet(name string, client *api.Client)
+
+	// RegionNum returns the number of regions being tracked within the
+	// controller. This is a convenience method used within testing, logging,
+	// and telemetry.
+	RegionNum() int
 }
 
 // TopologyController is the interface that must be satisfied in order to

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) James Rasell
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/rasorp/attila/internal/helper/pointer"
+	"github.com/rasorp/attila/internal/helper/test/mock"
+	"github.com/rasorp/attila/internal/server/state"
+	store "github.com/rasorp/attila/internal/state"
+)
+
+func TestServer_restore(t *testing.T) {
+
+	cfg := DefaultConfig()
+
+	cfg.State.File = &store.FileConfig{
+		Enable: pointer.Of(true),
+		Path:   t.TempDir(),
+	}
+
+	// Start an initial server and write a region to state. This acts as the
+	// restore point for testing.
+	startServer, err := NewServer(cfg)
+	must.NoError(t, err)
+	must.NotNil(t, startServer)
+
+	_, err = startServer.state.Region().Create(
+		&state.RegionCreateReq{Region: mock.Region()},
+	)
+	must.Nil(t, err)
+
+	// Stop the server, so we can free the listener.
+	startServer.Stop()
+
+	// Build a new server and test that the Nomad controller has the expected
+	// number of regions being tracked.
+	restoreServer, err := NewServer(cfg)
+	must.NoError(t, err)
+	must.NotNil(t, restoreServer)
+
+	must.Eq(t, 1, restoreServer.nomadController.RegionNum())
+
+	restoreServer.Stop()
+}


### PR DESCRIPTION
When the Attila server starts, and existing Nomad regions should have their API client restored into the Nomad controller. Without this, the controller will only be populated when a region is written to state via the HTTP API.