### PR TITLE
reg rule: Update contexts from string to richer object.

### DIFF
--- a/docs/demo/attila_job_reg_rule.hcl
+++ b/docs/demo/attila_job_reg_rule.hcl
@@ -1,5 +1,6 @@
-name            = "europe-platform"
-region_contexts = ["namespace"]
+name = "europe-platform"
+
+region_context { kind = "namespace" }
 
 region_picker "europe-region" {
   provider = "expr"

--- a/internal/cmd/job/register/rule/list.go
+++ b/internal/cmd/job/register/rule/list.go
@@ -60,7 +60,7 @@ func formatRegionContexts(ctxs []api.JobRegisterRuleRegionContext) string {
 	ctxStrings := make([]string, len(ctxs))
 
 	for i, ctx := range ctxs {
-		ctxStrings[i] = string(ctx)
+		ctxStrings[i] = ctx.Kind
 	}
 
 	return strings.Join(ctxStrings, ", ")

--- a/internal/cmd/job/register/rule/rule.go
+++ b/internal/cmd/job/register/rule/rule.go
@@ -43,7 +43,7 @@ func outputRule(cliCtx *cli.Context, r *api.JobRegisterRule) {
 func contextsAsString(ctxs []*api.JobRegisterRuleRegionContext) string {
 	var s []string
 	for _, regionCtx := range ctxs {
-		s = append(s, string(*regionCtx))
+		s = append(s, regionCtx.Kind)
 	}
 	return strings.Join(s, ", ")
 }

--- a/internal/domain/job_register_rule.go
+++ b/internal/domain/job_register_rule.go
@@ -47,9 +47,21 @@ type JobRegisterRuleStub struct {
 	RegionContexts []JobRegisterRuleRegionContext `json:"region_contexts"`
 }
 
-type JobRegisterRuleRegionContext string
+// JobRegisterRuleRegionContext is a way to make additional resource information
+// about the region being available to the picker.
+type JobRegisterRuleRegionContext struct {
+
+	// Kind is the context that will be made available to the rule picker. It
+	// currently supports namespace and node-pool.
+	Kind string `json:"kind"`
+}
 
 const (
-	JobRegisterRuleContextNamespace JobRegisterRuleRegionContext = "namespace"
-	JobRegisterRuleContextNodePool  JobRegisterRuleRegionContext = "node-pool"
+	// JobRegisterRuleContextKindNamespace is the context kind that supplies
+	// information from Nomad's "v1/namespaces" endpoint.
+	JobRegisterRuleContextKindNamespace = "namespace"
+
+	// JobRegisterRuleContextKindNodepool is the context kind that supplies
+	// information from Nomad's "v1/node/pools" endpoint.
+	JobRegisterRuleContextKindNodepool = "node-pool"
 )

--- a/internal/helper/file/parse_test.go
+++ b/internal/helper/file/parse_test.go
@@ -18,8 +18,9 @@ func TestParseConfig_HCL_NormalizesRegionPickerConfig(t *testing.T) {
 	testFile := filepath.Join(testDir, "rule.hcl")
 
 	must.NoError(t, os.WriteFile(testFile, []byte(`
-name            = "platform_namespace"
-region_contexts = ["namespace"]
+name = "platform_namespace"
+
+region_context { kind = "namespace" }
 
 region_picker "europe-region" {
   provider = "expr"

--- a/internal/helper/test/mock/mock.go
+++ b/internal/helper/test/mock/mock.go
@@ -65,8 +65,8 @@ func JobRegistrationRule() *domain.JobRegisterRule {
 	return &domain.JobRegisterRule{
 		Name: "mock-" + ulid.Make().String(),
 		RegionContexts: []domain.JobRegisterRuleRegionContext{
-			domain.JobRegisterRuleContextNamespace,
-			domain.JobRegisterRuleContextNodePool,
+			{Kind: domain.JobRegisterRuleContextKindNamespace},
+			{Kind: domain.JobRegisterRuleContextKindNodepool},
 		},
 		RegionPickers: []*jobsdk.RegionPickerConfig{
 			{

--- a/internal/nomad/job/planner.go
+++ b/internal/nomad/job/planner.go
@@ -203,7 +203,7 @@ func domainJobRegisterRuleToPickerRule(rule *domain.JobRegisterRule) *jobsdk.Reg
 
 	regionContexts := make([]string, 0, len(rule.RegionContexts))
 	for _, regionContext := range rule.RegionContexts {
-		regionContexts = append(regionContexts, string(regionContext))
+		regionContexts = append(regionContexts, regionContext.Kind)
 	}
 
 	var metadata *jobsdk.RegionPickerMetadata
@@ -225,15 +225,15 @@ func domainJobRegisterRuleToPickerRule(rule *domain.JobRegisterRule) *jobsdk.Reg
 func populateRegionContext(
 	rule *domain.JobRegisterRule, client *api.Client, ctx map[string]any) error {
 	for _, regionContext := range rule.RegionContexts {
-		switch regionContext {
-		case domain.JobRegisterRuleContextNamespace:
+		switch regionContext.Kind {
+		case domain.JobRegisterRuleContextKindNamespace:
 			namespaceList, _, err := client.Namespaces().List(nil)
 			if err != nil {
 				return err
 			}
 			ctx["region_namespace"] = namespaceList
 
-		case domain.JobRegisterRuleContextNodePool:
+		case domain.JobRegisterRuleContextKindNodepool:
 			nodepoolList, _, err := client.NodePools().List(nil)
 			if err != nil {
 				return err

--- a/pkg/api/job_register.go
+++ b/pkg/api/job_register.go
@@ -117,16 +117,28 @@ func (a *JobRegisterMethods) List(ctx context.Context) (*JobRegisterMethodListRe
 
 type JobRegisterRule struct {
 	Name           string                          `hcl:"name" json:"name"`
-	RegionContexts []*JobRegisterRuleRegionContext `hcl:"region_contexts,optional" json:"region_contexts"`
+	RegionContexts []*JobRegisterRuleRegionContext `hcl:"region_context,block" json:"region_contexts"`
 	RegionPickers  []*JobRegisterRegionPicker      `hcl:"region_picker,block" json:"region_pickers"`
 	Metadata       *Metadata                       `hcl:"metadata" json:"metadata"`
 }
 
-type JobRegisterRuleRegionContext string
+// JobRegisterRuleRegionContext is a way to make additional resource information
+// about the region being available to the picker.
+type JobRegisterRuleRegionContext struct {
+
+	// Kind is the context that will be made available to the rule picker. It
+	// currently supports namespace and node-pool.
+	Kind string `hcl:"kind" json:"kind"`
+}
 
 const (
-	JobRegisterRuleContextNamespace JobRegisterRuleRegionContext = "namespace"
-	JobRegisterRuleContextNodePool  JobRegisterRuleRegionContext = "node-pool"
+	// JobRegisterRuleContextKindNamespace is the context kind that supplies
+	// information from Nomad's "v1/namespaces" endpoint.
+	JobRegisterRuleContextKindNamespace = "namespace"
+
+	// JobRegisterRuleContextKindNodepool is the context kind that supplies
+	// information from Nomad's "v1/node/pools" endpoint.
+	JobRegisterRuleContextKindNodepool = "node-pool"
 )
 
 // JobRegisterRegionPicker contains all the configuration required to run the


### PR DESCRIPTION
The contexts were plain strings which offered little flexibility for the future. Updating this config object to allow for richer additions opens up the potential to offer filtering and other such functionality.